### PR TITLE
Feat: 회원 관련 entity 및 repository 작성

### DIFF
--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -1,0 +1,11 @@
+# Database Docs
+
+## Diagram
+![image](https://github.com/user-attachments/assets/cf42188f-a8e5-4f9b-b671-0438491dd87e)<br/><br/>
+
+
+### History
+
+---
+<b>24.09.23</b></br>
+user_info, admin_login, social_login, social_provider 테이블 추가<br/>

--- a/docs/database/entity.sql
+++ b/docs/database/entity.sql
@@ -1,0 +1,38 @@
+create table user_info
+(
+  user_id    bigint primary key auto_increment not null,
+  nickname   varchar(12)                       not null,
+  email      text,
+  role       varchar(20)                       not null,
+  state      varchar(20)                       not null,
+  created_at TIMESTAMP                         not null,
+  updated_at TIMESTAMP                         not null
+);
+
+create table admin_login
+(
+  admin_id bigint primary key not null,
+  id       text               not null,
+  password text               not null,
+  salt     varchar(10)        not null
+);
+
+create table social_login
+(
+  user_id   bigint primary key not null,
+  social_id text               not null,
+  provider  varchar(20)        not null
+);
+
+create table social_provider
+(
+  provider varchar(20) primary key not null,
+  state    varchar(20)             not null
+);
+
+alter table admin_login
+  add foreign key (admin_id) references user_info (user_id);
+alter table social_login
+  add foreign key (user_id) references user_info (user_id);
+alter table social_login
+  add foreign key (provider) references social_provider (provider);

--- a/src/main/java/ds/project/toy/domain/user/entity/AdminLogin.java
+++ b/src/main/java/ds/project/toy/domain/user/entity/AdminLogin.java
@@ -1,0 +1,41 @@
+package ds.project.toy.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "admin_login")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class AdminLogin {
+
+    @Id
+    @Column(name = "admin_id")
+    private Long adminId;
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "admin_id", referencedColumnName = "user_id")
+    private UserInfo userInfo;
+    @Column(name = "id")
+    private String id;
+    @Column(name = "password")
+    private String password;
+    @Column(name = "salt")
+    private String salt;
+
+    @Builder
+    private AdminLogin(Long adminId, UserInfo userInfo, String id, String password, String salt) {
+        this.adminId = adminId;
+        this.userInfo = userInfo;
+        this.id = id;
+        this.password = password;
+        this.salt = salt;
+    }
+}

--- a/src/main/java/ds/project/toy/domain/user/entity/SocialLogin.java
+++ b/src/main/java/ds/project/toy/domain/user/entity/SocialLogin.java
@@ -1,0 +1,40 @@
+package ds.project.toy.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "social_login")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SocialLogin {
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "user_id", referencedColumnName = "user_id")
+    private UserInfo userInfo;
+    @Column(name = "social_id")
+    private String socialId;
+    @ManyToOne
+    @JoinColumn(name = "provider")
+    private SocialProvider provider;
+
+    @Builder
+    private SocialLogin(Long userId, UserInfo userInfo, String socialId, SocialProvider provider) {
+        this.userId = userId;
+        this.userInfo = userInfo;
+        this.socialId = socialId;
+        this.provider = provider;
+    }
+}

--- a/src/main/java/ds/project/toy/domain/user/entity/SocialProvider.java
+++ b/src/main/java/ds/project/toy/domain/user/entity/SocialProvider.java
@@ -1,0 +1,29 @@
+package ds.project.toy.domain.user.entity;
+
+import ds.project.toy.domain.user.vo.Provider;
+import ds.project.toy.domain.user.vo.SocialProviderState;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "social_provider")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SocialProvider {
+
+    @Id
+    @Column(name = "provider")
+    private Provider provider;
+    @Column(name = "state")
+    private SocialProviderState state;
+
+    @Builder
+    private SocialProvider(Provider provider, SocialProviderState state) {
+        this.provider = provider;
+        this.state = state;
+    }
+}

--- a/src/main/java/ds/project/toy/domain/user/entity/UserInfo.java
+++ b/src/main/java/ds/project/toy/domain/user/entity/UserInfo.java
@@ -1,0 +1,57 @@
+package ds.project.toy.domain.user.entity;
+
+import static jakarta.persistence.EnumType.STRING;
+
+import ds.project.toy.domain.user.vo.UserInfoRole;
+import ds.project.toy.domain.user.vo.UserInfoState;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@Entity(name = "user_info")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class UserInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+    @Column(name = "nickname")
+    private String nickname;
+    @Column(name = "email")
+    private String email;
+    @Column(name = "role")
+    @Enumerated(STRING)
+    private UserInfoRole role;
+    @Column(name = "state")
+    @Enumerated(STRING)
+    private UserInfoState state;
+    @Column(name = "created_at")
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private UserInfo(String nickname, String email, UserInfoRole role, UserInfoState state,
+        LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.nickname = nickname;
+        this.email = email;
+        this.role = role;
+        this.state = state;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/ds/project/toy/domain/user/repository/AdminLoginRepository.java
+++ b/src/main/java/ds/project/toy/domain/user/repository/AdminLoginRepository.java
@@ -1,0 +1,10 @@
+package ds.project.toy.domain.user.repository;
+
+import ds.project.toy.domain.user.entity.AdminLogin;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AdminLoginRepository extends JpaRepository<AdminLogin, Long> {
+
+}

--- a/src/main/java/ds/project/toy/domain/user/repository/SocialLoginRepository.java
+++ b/src/main/java/ds/project/toy/domain/user/repository/SocialLoginRepository.java
@@ -1,0 +1,10 @@
+package ds.project.toy.domain.user.repository;
+
+import ds.project.toy.domain.user.entity.SocialLogin;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SocialLoginRepository extends JpaRepository<SocialLogin, Long> {
+
+}

--- a/src/main/java/ds/project/toy/domain/user/repository/SocialProviderRepository.java
+++ b/src/main/java/ds/project/toy/domain/user/repository/SocialProviderRepository.java
@@ -1,0 +1,10 @@
+package ds.project.toy.domain.user.repository;
+
+import ds.project.toy.domain.user.entity.SocialProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SocialProviderRepository extends JpaRepository<SocialProvider, String> {
+
+}

--- a/src/main/java/ds/project/toy/domain/user/repository/UserInfoRepository.java
+++ b/src/main/java/ds/project/toy/domain/user/repository/UserInfoRepository.java
@@ -1,0 +1,10 @@
+package ds.project.toy.domain.user.repository;
+
+import ds.project.toy.domain.user.entity.UserInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserInfoRepository extends JpaRepository<UserInfo, Long> {
+
+}

--- a/src/main/java/ds/project/toy/domain/user/vo/Provider.java
+++ b/src/main/java/ds/project/toy/domain/user/vo/Provider.java
@@ -1,0 +1,11 @@
+package ds.project.toy.domain.user.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Provider {
+    KAKAO("카카오");
+    private final String name;
+}

--- a/src/main/java/ds/project/toy/domain/user/vo/SocialProviderState.java
+++ b/src/main/java/ds/project/toy/domain/user/vo/SocialProviderState.java
@@ -1,0 +1,12 @@
+package ds.project.toy.domain.user.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SocialProviderState {
+    ACTIVE("활성화"),
+    INACTIVE("비활성화");
+    private final String name;
+}

--- a/src/main/java/ds/project/toy/domain/user/vo/UserInfoRole.java
+++ b/src/main/java/ds/project/toy/domain/user/vo/UserInfoRole.java
@@ -1,0 +1,12 @@
+package ds.project.toy.domain.user.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserInfoRole {
+    ROLE_USER("USER"),
+    ROLE_ADMIN("ADMIN");
+    private final String name;
+}

--- a/src/main/java/ds/project/toy/domain/user/vo/UserInfoState.java
+++ b/src/main/java/ds/project/toy/domain/user/vo/UserInfoState.java
@@ -1,0 +1,13 @@
+package ds.project.toy.domain.user.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserInfoState {
+    ACTIVE("활동"),
+    WITHDRAWN("탈퇴"),
+    BAN("정지");
+    private final String name;
+}


### PR DESCRIPTION
## 이슈
- [x] #21 
## 작업 내용
- user_info entity 작성
- admin_login entity 작성
- social_login entity 작성
- social_provider entity 작성
- 각 entity 중 provider, role, state 경우 enum으로 관리
- 회원 관련 table 생성 sql 작성
- docs readme에 diargram 작성 및 history 작성