### PR TITLE
Feat: 관리자 로그인

### DIFF
--- a/.github/workflows/sonarcloud-analyze.yml
+++ b/.github/workflows/sonarcloud-analyze.yml
@@ -40,3 +40,4 @@ jobs:
             -Dsonar.host.url=https://sonarcloud.io
             -Dsonar.java.binaries=build/classes
             -Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
+            -Dsonar.coverage.exclusions=**/test/**

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,6 @@ jacocoTestReport {
         files(classDirectories.files.collect {
           fileTree(dir: it, exclude: [
               '**/ds/project/toy/ToyApplication.class',
-              '**/test/**',
           ])
         })
     )

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,8 @@ jacocoTestReport {
     classDirectories.setFrom(
         files(classDirectories.files.collect {
           fileTree(dir: it, exclude: [
-              '**/ds/project/toy/ToyApplication.class'
+              '**/ds/project/toy/ToyApplication.class',
+              '**/test/**',
           ])
         })
     )

--- a/src/main/java/ds/project/toy/api/controller/admin/AdminController.java
+++ b/src/main/java/ds/project/toy/api/controller/admin/AdminController.java
@@ -1,0 +1,26 @@
+package ds.project.toy.api.controller.admin;
+
+import ds.project.toy.api.controller.admin.dto.request.AdminLoginRequest;
+import ds.project.toy.api.service.admin.AdminService;
+import ds.project.toy.global.common.vo.AuthToken;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthToken> adminLogin(
+        @Valid @RequestBody AdminLoginRequest request) {
+        return ResponseEntity.ok(adminService.adminLogin(request.toServiceDto()));
+    }
+}

--- a/src/main/java/ds/project/toy/api/controller/admin/dto/request/AdminLoginRequest.java
+++ b/src/main/java/ds/project/toy/api/controller/admin/dto/request/AdminLoginRequest.java
@@ -1,0 +1,37 @@
+package ds.project.toy.api.controller.admin.dto.request;
+
+import ds.project.toy.api.service.admin.dto.AdminLoginServiceDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AdminLoginRequest {
+
+    @Schema(description = "아이디", defaultValue = "dsk0820")
+    @NotBlank(message = "아이디를 입력해주세요.")
+    private String id;
+    @Schema(description = "비밀번호", defaultValue = "pssword123!")
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+    @Builder
+    private AdminLoginRequest(String id, String password) {
+        this.id = id;
+        this.password = password;
+    }
+
+    public static AdminLoginRequest of(String id, String password) {
+        return AdminLoginRequest.builder()
+            .id(id)
+            .password(password)
+            .build();
+    }
+
+    public AdminLoginServiceDto toServiceDto() {
+        return AdminLoginServiceDto.of(this.id, this.password);
+    }
+}

--- a/src/main/java/ds/project/toy/api/service/admin/AdminService.java
+++ b/src/main/java/ds/project/toy/api/service/admin/AdminService.java
@@ -1,0 +1,9 @@
+package ds.project.toy.api.service.admin;
+
+import ds.project.toy.api.service.admin.dto.AdminLoginServiceDto;
+import ds.project.toy.global.common.vo.AuthToken;
+
+public interface AdminService {
+
+    AuthToken adminLogin(AdminLoginServiceDto serviceDto);
+}

--- a/src/main/java/ds/project/toy/api/service/admin/AdminServiceImpl.java
+++ b/src/main/java/ds/project/toy/api/service/admin/AdminServiceImpl.java
@@ -1,0 +1,48 @@
+package ds.project.toy.api.service.admin;
+
+import ds.project.toy.api.service.admin.dto.AdminLoginServiceDto;
+import ds.project.toy.domain.user.entity.AdminLogin;
+import ds.project.toy.domain.user.repository.AdminLoginRepository;
+import ds.project.toy.global.common.exception.CustomException;
+import ds.project.toy.global.common.exception.ResponseCode;
+import ds.project.toy.global.common.vo.AuthToken;
+import ds.project.toy.global.config.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminServiceImpl implements AdminService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final AdminLoginRepository adminLoginRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public AuthToken adminLogin(AdminLoginServiceDto serviceDto) {
+        AdminLogin adminLogin = adminLoginFindBy(serviceDto.getId());
+        if (!checkPassword(adminLogin, serviceDto.getPassword())) {
+            throw new CustomException(ResponseCode.FAILED_ADMIN_LOGIN);
+        }
+
+        return jwtTokenProvider.createTokenAndStore(String.valueOf(adminLogin.getAdminId()));
+    }
+
+    private boolean checkPassword(AdminLogin adminLogin, String password) {
+        return passwordEncoder.matches(
+            createSaltedPassword(password, adminLogin.getSalt()), adminLogin.getPassword()
+        );
+    }
+
+    private String createSaltedPassword(String password, String salt) {
+        return password + salt;
+    }
+
+    private AdminLogin adminLoginFindBy(String id) {
+        return adminLoginRepository.findById(id)
+            .orElseThrow(() -> new CustomException(ResponseCode.FAILED_ADMIN_LOGIN));
+    }
+}

--- a/src/main/java/ds/project/toy/api/service/admin/dto/AdminLoginServiceDto.java
+++ b/src/main/java/ds/project/toy/api/service/admin/dto/AdminLoginServiceDto.java
@@ -1,0 +1,24 @@
+package ds.project.toy.api.service.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AdminLoginServiceDto {
+
+    private String id;
+    private String password;
+
+    @Builder
+    private AdminLoginServiceDto(String id, String password) {
+        this.id = id;
+        this.password = password;
+    }
+    public static AdminLoginServiceDto of(String id, String password) {
+        return AdminLoginServiceDto.builder()
+            .id(id)
+            .password(password).build();
+    }
+}

--- a/src/main/java/ds/project/toy/domain/user/entity/AdminLogin.java
+++ b/src/main/java/ds/project/toy/domain/user/entity/AdminLogin.java
@@ -38,4 +38,14 @@ public class AdminLogin {
         this.password = password;
         this.salt = salt;
     }
+
+    public static AdminLogin of(UserInfo userInfo, String id, String password, String salt) {
+        return AdminLogin.builder()
+            .userInfo(userInfo)
+            .id(id)
+            .password(password)
+            .salt(salt)
+            .build();
+    }
+
 }

--- a/src/main/java/ds/project/toy/domain/user/repository/AdminLoginRepository.java
+++ b/src/main/java/ds/project/toy/domain/user/repository/AdminLoginRepository.java
@@ -1,10 +1,12 @@
 package ds.project.toy.domain.user.repository;
 
 import ds.project.toy.domain.user.entity.AdminLogin;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AdminLoginRepository extends JpaRepository<AdminLogin, Long> {
 
+    Optional<AdminLogin> findById(String email);
 }

--- a/src/main/java/ds/project/toy/global/common/exception/ResponseCode.java
+++ b/src/main/java/ds/project/toy/global/common/exception/ResponseCode.java
@@ -20,6 +20,10 @@ public enum ResponseCode {
     NICKNAME_ALREADY_IN_USE("USER-ERR-002", "유저가 현재 사용 중인 닉네임입니다."),
     DUPLICATE_NICKNAME("USER-ERR-003", "이미 존재하는 닉네임입니다."),
 
+    //ADMIN
+    NOTFOUND_ADMIN("ADMIN-ERR-001", "존재하지 않은 관리자입니다."),
+    FAILED_ADMIN_LOGIN("ADMIN-ERR-002","아이디 또는 비밀번호가 잘못 되었습니다."),
+
     //GLOBAL
     BAD_REQUEST("GLB-ERR-001", "잘못된 요청입니다."),
     METHOD_NOT_ALLOWED("GLB-ERR-002", "허용되지 않은 메서드입니다."),

--- a/src/main/java/ds/project/toy/global/config/security/SecurityConfig.java
+++ b/src/main/java/ds/project/toy/global/config/security/SecurityConfig.java
@@ -67,8 +67,9 @@ public class SecurityConfig {
                 .requestMatchers("/actuator/**", "/swagger-ui/**",
                     "/swagger-resources/**", "/api-docs/**").permitAll()
                 .requestMatchers("/login/**").permitAll()
-                .requestMatchers(HttpMethod.POST, "/auth/token/reissue").permitAll()
+                .requestMatchers(HttpMethod.POST, "/auth/token/reissue","/admin/login").permitAll()
                 .requestMatchers("/member/**").hasRole(UserInfoRole.ROLE_USER.getName())
+                .requestMatchers("/**").hasRole(UserInfoRole.ROLE_ADMIN.getName())
                 .anyRequest().authenticated()
             )
             .addFilterAfter(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/test/java/ds/project/toy/ControllerTestSupport.java
+++ b/src/test/java/ds/project/toy/ControllerTestSupport.java
@@ -2,8 +2,10 @@ package ds.project.toy;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import ds.project.toy.api.controller.admin.AdminController;
 import ds.project.toy.api.controller.auth.AuthController;
 import ds.project.toy.api.controller.user.UserController;
+import ds.project.toy.api.service.admin.AdminService;
 import ds.project.toy.api.service.auth.AuthService;
 import ds.project.toy.api.service.user.UserService;
 import ds.project.toy.global.config.security.jwt.JwtTokenProvider;
@@ -17,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(controllers = {
     AuthController.class,
     UserController.class,
+    AdminController.class,
 })
 @WithMockUser
 public abstract class ControllerTestSupport {
@@ -30,6 +33,8 @@ public abstract class ControllerTestSupport {
     protected AuthService authService;
     @MockBean
     protected UserService userService;
+    @MockBean
+    protected AdminService adminService;
     @MockBean
     protected JwtTokenProvider jwtTokenProvider;
     @MockBean

--- a/src/test/java/ds/project/toy/IntegrationTestSupport.java
+++ b/src/test/java/ds/project/toy/IntegrationTestSupport.java
@@ -1,6 +1,7 @@
 package ds.project.toy;
 
 
+import ds.project.toy.api.service.admin.AdminService;
 import ds.project.toy.api.service.auth.AuthService;
 import ds.project.toy.api.service.user.UserService;
 import ds.project.toy.domain.user.repository.AdminLoginRepository;
@@ -36,6 +37,8 @@ public abstract class IntegrationTestSupport {
     protected AuthService authService;
     @Autowired
     protected UserService userService;
+    @Autowired
+    protected AdminService adminService;
 
     @Autowired
     protected AdminLoginRepository adminLoginRepository;

--- a/src/test/java/ds/project/toy/api/controller/admin/AdminControllerTest.java
+++ b/src/test/java/ds/project/toy/api/controller/admin/AdminControllerTest.java
@@ -1,0 +1,42 @@
+package ds.project.toy.api.controller.admin;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ds.project.toy.ControllerTestSupport;
+import ds.project.toy.api.controller.admin.dto.request.AdminLoginRequest;
+import ds.project.toy.global.common.vo.AuthToken;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+
+class AdminControllerTest extends ControllerTestSupport {
+
+    @DisplayName(value = "관리자가 로그인 한다.")
+    @Test
+    void adminLogin() throws Exception {
+        //given
+        String id = "id";
+        String password = "password";
+        AdminLoginRequest request = AdminLoginRequest.of(id, password);
+        AuthToken authToken = AuthToken.of("accessToken2", "refreshToken2");
+        given(adminService.adminLogin(any()))
+            .willReturn(authToken);
+        //when then
+        mockMvc.perform(
+                post("/admin/login")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON).with(csrf())
+            )
+            .andExpect(status().isOk())
+            .andExpectAll(
+                jsonPath("$.accessToken").value(authToken.getAccessToken()),
+                jsonPath("$.refreshToken").value(authToken.getRefreshToken())
+            );
+    }
+}

--- a/src/test/java/ds/project/toy/api/service/admin/AdminServiceTest.java
+++ b/src/test/java/ds/project/toy/api/service/admin/AdminServiceTest.java
@@ -1,0 +1,87 @@
+package ds.project.toy.api.service.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ds.project.toy.IntegrationTestSupport;
+import ds.project.toy.api.service.admin.dto.AdminLoginServiceDto;
+import ds.project.toy.domain.user.entity.AdminLogin;
+import ds.project.toy.domain.user.entity.UserInfo;
+import ds.project.toy.domain.user.vo.UserInfoRole;
+import ds.project.toy.domain.user.vo.UserInfoState;
+import ds.project.toy.global.common.exception.CustomException;
+import ds.project.toy.global.common.exception.ResponseCode;
+import ds.project.toy.global.common.vo.AuthToken;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AdminServiceTest extends IntegrationTestSupport {
+
+    @DisplayName(value = "id와 password로 관리자 로그인 한다.")
+    @Test
+    void adminLogin() {
+        //given
+        String id = "id";
+        String password = "password";
+        String salt = "s1a2d3f4g4";
+        String encodedPassword = passwordEncoder.encode(password+salt);
+        UserInfo userInfo = createUserInfo("nickname", "email@gmai.com", UserInfoRole.ROLE_ADMIN,
+            UserInfoState.ACTIVE);
+        AdminLogin adminLogin = adminLoginRepository.save(createAdminLogin(userInfo, id, encodedPassword,salt));
+        AdminLoginServiceDto dto = AdminLoginServiceDto.of(id, password);
+        //when
+        AuthToken authToken = adminService.adminLogin(dto);
+        //then
+        assertThat(adminLogin.getAdminId()).hasToString(
+            jwtTokenProvider.getAuthentication(authToken.getAccessToken()).getName());
+    }
+
+    @DisplayName(value = "id와 password로 관리자 로그인 할때 id가 틀릴 경우 예외가 발생한다.")
+    @Test
+    void adminLoginWithWrongID() {
+        //given
+        String id = "id";
+        String wrongId = "wrongId";
+        String password = "password";
+        String salt = "s1a2d3f4g4";
+        String encodedPassword = passwordEncoder.encode(password+salt);
+        UserInfo userInfo = createUserInfo("nickname", "email@gmai.com", UserInfoRole.ROLE_ADMIN,
+            UserInfoState.ACTIVE);
+        adminLoginRepository.save(createAdminLogin(userInfo, id, encodedPassword,salt));
+        AdminLoginServiceDto dto = AdminLoginServiceDto.of(wrongId, password);
+        //when
+        assertThatThrownBy(() -> adminService.adminLogin(dto))
+            .isInstanceOf(CustomException.class)
+            .extracting("responseCode")
+            .isEqualTo(ResponseCode.FAILED_ADMIN_LOGIN);
+    }
+
+    @DisplayName(value = "id와 password로 관리자 로그인 할때 password가 틀릴 경우 예외가 발생한다.")
+    @Test
+    void adminLoginWithWrongPassword() {
+        //given
+        String id = "id";
+        String wrongPassword = "wrongPassword";
+        String password = "password";
+        String salt = "s1a2d3f4g4";
+        String encodedPassword = passwordEncoder.encode(password+salt);
+        UserInfo userInfo = createUserInfo("nickname", "email@gmai.com", UserInfoRole.ROLE_ADMIN,
+            UserInfoState.ACTIVE);
+        adminLoginRepository.save(createAdminLogin(userInfo, id, encodedPassword,salt));
+        AdminLoginServiceDto dto = AdminLoginServiceDto.of(id, wrongPassword);
+        //when
+        assertThatThrownBy(() -> adminService.adminLogin(dto))
+            .isInstanceOf(CustomException.class)
+            .extracting("responseCode")
+            .isEqualTo(ResponseCode.FAILED_ADMIN_LOGIN);
+    }
+
+    private UserInfo createUserInfo(String nickname, String email,
+        UserInfoRole role, UserInfoState state) {
+        return UserInfo.of(nickname, email, role, state);
+    }
+
+    private AdminLogin createAdminLogin(UserInfo userInfo, String id, String password, String salt) {
+        return AdminLogin.of(userInfo, id, password, salt);
+    }
+}


### PR DESCRIPTION
##  이슈
- [x] #39
## 작업 내용
- id, password로 로그인
- salt, bcrypt 방식으로 암호화
- id 또는 password 잘못될 시 같은 예외처리
- admin의 경우 모든 API 접근 가능