### PR TITLE
Test: 테스트 코드 작성 및 수정, jacoco report 수정 

### DIFF
--- a/.github/workflows/sonarcloud-analyze.yml
+++ b/.github/workflows/sonarcloud-analyze.yml
@@ -2,7 +2,7 @@ name: SonarCloud Code Analyze
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
   workflow_dispatch:
 
 jobs:
@@ -23,21 +23,22 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build the project
-        run: ./gradlew build
-
-      - name: Analyze with SonarCloud
-        uses: SonarSource/sonarcloud-github-action@master
-        id: analyze-sonarcloud
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: Cache SonarQube Cloud packages
+        uses: actions/cache@v4
         with:
-          args: |
-            -Dsonar.projectKey=wcorn_toy
-            -Dsonar.organization=wcorn-sonar-cloud
-            -Dsonar.host.url=https://sonarcloud.io
-            -Dsonar.java.binaries=build/classes
-            -Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
-            -Dsonar.coverage.exclusions=**/test/**
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew build sonar --info

--- a/.github/workflows/sonarcloud-analyze.yml
+++ b/.github/workflows/sonarcloud-analyze.yml
@@ -40,4 +40,4 @@ jobs:
             -Dsonar.host.url=https://sonarcloud.io
             -Dsonar.java.binaries=build/classes
             -Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
-            -Dsonar.coverage.exclusions=**/test/**,**/ds/project/toy/ToyApplication.class,**/ds/project/toy/global/common/exception/**,**/dto/**,**/config/*.class,**/ds/project/toy/global/common/api/**,**/ds/project/toy/global/util/MinioUtil.class,**/ds/project/toy/global/util/RedisUtil.class
+            -Dsonar.coverage.exclusions=**/test/**,**/ds/project/toy/ToyApplication.class,**/ds/project/toy/global/common/exception/**,**/dto/**,**/config/*.class,**/ds/project/toy/global/common/api/**,**/ds/project/toy/global/util/MinioUtil.class,**/ds/project/toy/global/util/RedisUtil.class,**/ds/project/toy/global/config/security/**

--- a/.github/workflows/sonarcloud-analyze.yml
+++ b/.github/workflows/sonarcloud-analyze.yml
@@ -2,7 +2,7 @@ name: SonarCloud Code Analyze
 
 on:
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:
@@ -23,22 +23,21 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Cache SonarQube Cloud packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
+      - name: Build the project
+        run: ./gradlew build
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-
-      - name: Build and analyze
+      - name: Analyze with SonarCloud
+        uses: SonarSource/sonarcloud-github-action@master
+        id: analyze-sonarcloud
+        continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew build sonar --info
+        with:
+          args: |
+            -Dsonar.projectKey=wcorn_toy
+            -Dsonar.organization=wcorn-sonar-cloud
+            -Dsonar.host.url=https://sonarcloud.io
+            -Dsonar.java.binaries=build/classes
+            -Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
+            -Dsonar.coverage.exclusions=**/test/**,**/ds/project/toy/ToyApplication.class,**/ds/project/toy/global/common/exception/**,**/dto/**,**/config/*.class,**/ds/project/toy/global/common/api/**,**/ds/project/toy/global/util/MinioUtil.class,**/ds/project/toy/global/util/RedisUtil.class

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ jacocoTestReport {
               '**/ds/project/toy/global/common/api/**',
               '**/ds/project/toy/global/util/MinioUtil.class',
               '**/ds/project/toy/global/util/RedisUtil.class',
+              '**/ds/project/toy/global/config/security/**',
           ])
         })
     )

--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,12 @@ jacocoTestReport {
         files(classDirectories.files.collect {
           fileTree(dir: it, exclude: [
               '**/ds/project/toy/ToyApplication.class',
+              '**/ds/project/toy/global/common/exception/**',
+              '**/dto/**',
+              '**/config/*.class',
+              '**/ds/project/toy/global/common/api/**',
+              '**/ds/project/toy/global/util/MinioUtil.class',
+              '**/ds/project/toy/global/util/RedisUtil.class',
           ])
         })
     )

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
   // actuator info git
   // https://plugins.gradle.org/plugin/com.gorylenko.gradle-git-properties
   id 'com.gorylenko.gradle-git-properties' version '2.4.2'
+  id "org.sonarqube" version "5.1.0.4882"
 }
 
 group = 'ds.project'
@@ -99,6 +100,14 @@ tasks.named('test') {
 
 jacoco {
   toolVersion = "0.8.12"
+}
+
+sonar {
+  properties {
+    property "sonar.projectKey", "wcorn_toy"
+    property "sonar.organization", "wcorn-sonar-cloud"
+    property "sonar.host.url", "https://sonarcloud.io"
+  }
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ plugins {
   // actuator info git
   // https://plugins.gradle.org/plugin/com.gorylenko.gradle-git-properties
   id 'com.gorylenko.gradle-git-properties' version '2.4.2'
-  id "org.sonarqube" version "5.1.0.4882"
 }
 
 group = 'ds.project'
@@ -100,14 +99,6 @@ tasks.named('test') {
 
 jacoco {
   toolVersion = "0.8.12"
-}
-
-sonar {
-  properties {
-    property "sonar.projectKey", "wcorn_toy"
-    property "sonar.organization", "wcorn-sonar-cloud"
-    property "sonar.host.url", "https://sonarcloud.io"
-  }
 }
 
 jacocoTestReport {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,1 @@
 rootProject.name = 'toy'
-include 'core'
-include 'domain'
-include 'system', 'system:core-web', 'system:core-web:api-core'
-include 'api','api:external-api'

--- a/src/main/java/ds/project/toy/api/controller/user/UserController.java
+++ b/src/main/java/ds/project/toy/api/controller/user/UserController.java
@@ -40,7 +40,7 @@ public class UserController {
         return ResponseEntity.ok(userService.changeNickname(request.toServiceDto(memberId)));
     }
 
-    @PatchMapping(value = "/profile_image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PatchMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ChangeProfileImageResponse> changeProfileImage(
         @RequestPart(value = "image") MultipartFile image) {
         if (!fileUtil.isImageFile(image)) {

--- a/src/main/java/ds/project/toy/api/controller/user/dto/response/GetUserProfileResponse.java
+++ b/src/main/java/ds/project/toy/api/controller/user/dto/response/GetUserProfileResponse.java
@@ -11,20 +11,20 @@ public class GetUserProfileResponse {
 
     private String nickname;
     private String email;
-    private String profile_image;
+    private String profileImage;
 
     @Builder
-    private GetUserProfileResponse(String nickname, String email, String profile_image) {
+    private GetUserProfileResponse(String nickname, String email, String profileImage) {
         this.nickname = nickname;
         this.email = email;
-        this.profile_image = profile_image;
+        this.profileImage = profileImage;
     }
 
-    public static GetUserProfileResponse of(String nickname, String email, String profile_image) {
+    public static GetUserProfileResponse of(String nickname, String email, String profileImage) {
         return GetUserProfileResponse.builder()
             .nickname(nickname)
             .email(email)
-            .profile_image(profile_image)
+            .profileImage(profileImage)
             .build();
     }
 
@@ -32,7 +32,7 @@ public class GetUserProfileResponse {
         return GetUserProfileResponse.builder()
             .nickname(userInfo.getNickname())
             .email(userInfo.getEmail())
-            .profile_image(userInfo.getProfileImage())
+            .profileImage(userInfo.getProfileImage())
             .build();
     }
 }

--- a/src/main/java/ds/project/toy/domain/user/entity/SocialLogin.java
+++ b/src/main/java/ds/project/toy/domain/user/entity/SocialLogin.java
@@ -39,15 +39,6 @@ public class SocialLogin {
         this.provider = provider;
     }
 
-    public static SocialLogin create(UserInfo userInfo, SocialProvider socialProvider,
-        String socialId) {
-        return SocialLogin.builder()
-            .provider(socialProvider)
-            .userInfo(userInfo)
-            .socialId(socialId)
-            .build();
-    }
-
     public static SocialLogin of(SocialProvider provider, String id, UserInfo userInfo) {
         return SocialLogin.builder()
             .provider(provider)

--- a/src/main/java/ds/project/toy/global/config/RedisConfig.java
+++ b/src/main/java/ds/project/toy/global/config/RedisConfig.java
@@ -1,11 +1,8 @@
 package ds.project.toy.global.config;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 

--- a/src/main/java/ds/project/toy/global/config/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/ds/project/toy/global/config/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -34,8 +34,8 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
     private Long extractUserId(Authentication authentication) {
         Object principal = authentication.getPrincipal();
-        if (principal instanceof OAuth2UserImpl) {
-            return ((OAuth2UserImpl) principal).getUserId();
+        if (principal instanceof OAuth2UserImpl oAuth2User) {
+            return oAuth2User.getUserId();
         }
         return null;
     }

--- a/src/main/java/ds/project/toy/global/config/security/oauth/service/OAuth2UserInfoFactory.java
+++ b/src/main/java/ds/project/toy/global/config/security/oauth/service/OAuth2UserInfoFactory.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 public class OAuth2UserInfoFactory {
 
+
     public static OAuth2UserInfo getOAuth2UserInfo(
         String registrationId, Map<String, Object> attributes) {
         if (OAuth2Provider.KAKAO.getRegistrationId().equals(registrationId)) {

--- a/src/main/java/ds/project/toy/global/config/security/oauth/service/OAuth2UserInfoFactory.java
+++ b/src/main/java/ds/project/toy/global/config/security/oauth/service/OAuth2UserInfoFactory.java
@@ -9,6 +9,8 @@ import java.util.Map;
 
 public class OAuth2UserInfoFactory {
 
+    private OAuth2UserInfoFactory() {
+    }
 
     public static OAuth2UserInfo getOAuth2UserInfo(
         String registrationId, Map<String, Object> attributes) {

--- a/src/main/java/ds/project/toy/global/config/security/oauth/service/OAuth2UserServiceImpl.java
+++ b/src/main/java/ds/project/toy/global/config/security/oauth/service/OAuth2UserServiceImpl.java
@@ -54,8 +54,8 @@ public class OAuth2UserServiceImpl extends DefaultOAuth2UserService {
         UserInfo userInfo = UserInfo.creatUser(oAuth2UserInfo.getEmail(),
             oAuth2UserInfo.getNickname());
         SocialProvider socialProvider = findActiveSocialProvider(oAuth2UserInfo.getProvider());
-        SocialLogin newSocialLogin = SocialLogin.create(userInfo, socialProvider,
-            oAuth2UserInfo.getId());
+        SocialLogin newSocialLogin = SocialLogin.of(socialProvider, oAuth2UserInfo.getId(),
+            userInfo);
         return socialLoginRepository.save(newSocialLogin);
     }
 

--- a/src/main/java/ds/project/toy/global/util/RedisUtil.java
+++ b/src/main/java/ds/project/toy/global/util/RedisUtil.java
@@ -3,11 +3,8 @@ package ds.project.toy.global.util;
 import ds.project.toy.global.common.vo.RedisPrefix;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.TimeUnit;
 
 @Component
 @RequiredArgsConstructor

--- a/src/test/java/ds/project/toy/api/controller/auth/AuthControllerTest.java
+++ b/src/test/java/ds/project/toy/api/controller/auth/AuthControllerTest.java
@@ -18,7 +18,7 @@ class AuthControllerTest extends ControllerTestSupport {
 
     @DisplayName(value = "토큰을 재발급한다.")
     @Test
-    public void reissuedToken() throws Exception {
+    void reissuedToken() throws Exception {
         //given
         ReissuedTokenRequest request = ReissuedTokenRequest.of("accessToken", "refreshToken");
         AuthToken authToken = AuthToken.of("accessToken2", "refreshToken2");

--- a/src/test/java/ds/project/toy/api/controller/user/UserControllerTest.java
+++ b/src/test/java/ds/project/toy/api/controller/user/UserControllerTest.java
@@ -99,7 +99,7 @@ class UserControllerTest extends ControllerTestSupport {
             .andExpectAll(
                 jsonPath("$.nickname").value(nickname),
                 jsonPath("$.email").value(email),
-                jsonPath("$.profile_image").value(profileImage)
+                jsonPath("$.profileImage").value(profileImage)
             );
         //then
 

--- a/src/test/java/ds/project/toy/api/controller/user/UserControllerTest.java
+++ b/src/test/java/ds/project/toy/api/controller/user/UserControllerTest.java
@@ -11,7 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import ds.project.toy.ControllerTestSupport;
 import ds.project.toy.api.controller.user.dto.request.ChangeNicknameRequest;
-import ds.project.toy.api.controller.user.dto.response.ChangeProfileImageResponse;
 import ds.project.toy.api.controller.user.dto.response.GetUserProfileResponse;
 import ds.project.toy.global.common.exception.ResponseCode;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +25,7 @@ class UserControllerTest extends ControllerTestSupport {
     @DisplayName(value = "닉네임을 변경한다.")
     @Test
     @WithMockUser(roles = "USER", username = "1")
-    public void changeNickname() throws Exception {
+    void changeNickname() throws Exception {
         //given
         String nickname = "nickname";
         ChangeNicknameRequest request = ChangeNicknameRequest.of(nickname);
@@ -42,7 +41,7 @@ class UserControllerTest extends ControllerTestSupport {
     @DisplayName(value = "프로필 이미지를 변경한다.")
     @Test
     @WithMockUser(roles = "USER", username = "1")
-    public void changeProfileImage() throws Exception {
+    void changeProfileImage() throws Exception {
         //given
         MockMultipartFile image = new MockMultipartFile("image", "test.jpeg",
             MediaType.IMAGE_JPEG_VALUE, "test".getBytes());
@@ -84,7 +83,7 @@ class UserControllerTest extends ControllerTestSupport {
     @DisplayName(value = "프로필을 조회한다.")
     @Test
     @WithMockUser(roles = "USER", username = "1")
-    public void getUserProfile() throws Exception {
+    void getUserProfile() throws Exception {
         //given
         String nickname = "nickname";
         String profileImage = "test.jpg";

--- a/src/test/java/ds/project/toy/api/controller/user/UserControllerTest.java
+++ b/src/test/java/ds/project/toy/api/controller/user/UserControllerTest.java
@@ -48,7 +48,7 @@ class UserControllerTest extends ControllerTestSupport {
         given(fileUtil.isImageFile(any())).willReturn(true);
         //when
         mockMvc.perform(
-                multipart(HttpMethod.PATCH, "/user/profile_image")
+                multipart(HttpMethod.PATCH, "/user/profile-image")
                     .file(image)
                     .with(csrf())
             )
@@ -67,7 +67,7 @@ class UserControllerTest extends ControllerTestSupport {
         given(fileUtil.isImageFile(any())).willReturn(false);
         //when
         mockMvc.perform(
-                multipart(HttpMethod.PATCH, "/user/profile_image")
+                multipart(HttpMethod.PATCH, "/user/profile-image")
                     .file(image)
                     .with(csrf())
             )

--- a/src/test/java/ds/project/toy/api/controller/user/UserControllerTest.java
+++ b/src/test/java/ds/project/toy/api/controller/user/UserControllerTest.java
@@ -11,7 +11,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import ds.project.toy.ControllerTestSupport;
 import ds.project.toy.api.controller.user.dto.request.ChangeNicknameRequest;
+import ds.project.toy.api.controller.user.dto.response.ChangeProfileImageResponse;
 import ds.project.toy.api.controller.user.dto.response.GetUserProfileResponse;
+import ds.project.toy.global.common.exception.ResponseCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
@@ -52,6 +54,29 @@ class UserControllerTest extends ControllerTestSupport {
                     .with(csrf())
             )
             .andExpect(status().isOk());
+        //then
+
+    }
+
+    @DisplayName(value = "프로필 이미지를 변경할때 유효한 이미지가 아닌 경우 예외가 발생한다.")
+    @Test
+    @WithMockUser(roles = "USER", username = "1")
+    void changeProfileImageWithInvalidImage() throws Exception {
+        //given
+        MockMultipartFile image = new MockMultipartFile("image", "test.jpeg",
+            null, "test".getBytes());
+        given(fileUtil.isImageFile(any())).willReturn(false);
+        //when
+        mockMvc.perform(
+                multipart(HttpMethod.PATCH, "/user/profile_image")
+                    .file(image)
+                    .with(csrf())
+            )
+            .andExpect(status().isBadRequest())
+            .andExpectAll(
+                jsonPath("$.code").value(ResponseCode.NOT_IMAGE.getCode()),
+                jsonPath("$.message").value(ResponseCode.NOT_IMAGE.getMessage())
+            );
         //then
 
     }

--- a/src/test/java/ds/project/toy/api/service/auth/AuthServiceTest.java
+++ b/src/test/java/ds/project/toy/api/service/auth/AuthServiceTest.java
@@ -19,7 +19,7 @@ class AuthServiceTest extends IntegrationTestSupport {
 
     @DisplayName(value = "토큰을 받아 기존 토큰을 삭제한 후 재생성한다.")
     @Test
-    public void reissuedToken() {
+    void reissuedToken() {
         //given
         UserInfo userInfo = userInfoRepository.save(
             createUserInfo("nickname", "email", UserInfoRole.ROLE_USER, UserInfoState.ACTIVE));
@@ -38,7 +38,7 @@ class AuthServiceTest extends IntegrationTestSupport {
 
     @DisplayName(value = "redis에 토큰이 안되어 있다면 토큰 재생성 시 예외가 발생한다.")
     @Test
-    public void reissuedTokenWithRedisNotStoredToken() {
+    void reissuedTokenWithRedisNotStoredToken() {
         //given
         AuthToken authToken = createToken(1);
         ReissuedTokenServiceDto dto = ReissuedTokenServiceDto.of(authToken.getAccessToken(),

--- a/src/test/java/ds/project/toy/api/service/user/UserServiceTest.java
+++ b/src/test/java/ds/project/toy/api/service/user/UserServiceTest.java
@@ -32,7 +32,7 @@ class UserServiceTest extends IntegrationTestSupport {
 
     @DisplayName(value = "변경할 닉네임을 받아 기존 닉네임을 변경한다.")
     @Test
-    public void changeNickname() {
+    void changeNickname() {
         //given
         String prevNickname = "prev";
         String nextNickname = "nickname";
@@ -54,7 +54,7 @@ class UserServiceTest extends IntegrationTestSupport {
 
     @DisplayName(value = "닉네임을 변경할 때 기존닉네임일 경우 예외가 발생한다.")
     @Test
-    public void changeNicknameWithNicknameAlreadyInUse() {
+    void changeNicknameWithNicknameAlreadyInUse() {
         //given
         String nickname = "nickname";
         SocialProvider socialProvider = socialProviderRepository.save(
@@ -74,7 +74,7 @@ class UserServiceTest extends IntegrationTestSupport {
 
     @DisplayName(value = "닉네임을 변경할 때 중복된 닉네임일 경우 예외가 발생한다.")
     @Test
-    public void changeNicknameWithDuplicateNickname() {
+    void changeNicknameWithDuplicateNickname() {
         //given
         String prevNickname = "prev";
         String duplicateNickname = "nickname";
@@ -99,7 +99,7 @@ class UserServiceTest extends IntegrationTestSupport {
 
     @DisplayName(value = "변경할 이미지를 받아 프로필 이미지를 수정한다.")
     @Test
-    public void changeProfileImage() {
+    void changeProfileImage() {
         //given
         MockMultipartFile mockMultipartFile = new MockMultipartFile("image", "test.jpeg",
             MediaType.IMAGE_JPEG_VALUE, "test".getBytes());
@@ -120,7 +120,7 @@ class UserServiceTest extends IntegrationTestSupport {
 
     @DisplayName(value = "프로필 이미지를 수정할 때 기존이미지가 있으면 기존이미지를 삭제한다.")
     @Test
-    public void changeProfileImageWithExistsProfileImage() {
+    void changeProfileImageWithExistsProfileImage() {
         //given
         MockMultipartFile mockMultipartFile = new MockMultipartFile("image", "test.jpeg",
             MediaType.IMAGE_JPEG_VALUE, "test".getBytes());
@@ -142,7 +142,7 @@ class UserServiceTest extends IntegrationTestSupport {
 
     @DisplayName(value = "유저 id로 유저 정보를 조회한다.")
     @Test
-    public void getUserProfile() {
+    void getUserProfile() {
         //given
         String nickname = "nickname";
         String email = "email@email.com";

--- a/src/test/java/ds/project/toy/api/service/user/UserServiceTest.java
+++ b/src/test/java/ds/project/toy/api/service/user/UserServiceTest.java
@@ -146,8 +146,8 @@ class UserServiceTest extends IntegrationTestSupport {
         //given
         String nickname = "nickname";
         String email = "email@email.com";
-        String profile_image = "profile_image.jpg";
-        UserInfo userInfo = userInfoRepository.save(createUserInfo(nickname, email, profile_image,
+        String profileImage = "profileImage.jpg";
+        UserInfo userInfo = userInfoRepository.save(createUserInfo(nickname, email, profileImage,
             UserInfoRole.ROLE_USER, UserInfoState.ACTIVE));
         GetUserProfileDto dto = GetUserProfileDto.of(userInfo.getUserId());
 
@@ -156,8 +156,8 @@ class UserServiceTest extends IntegrationTestSupport {
 
         //then
         assertThat(response)
-            .extracting("nickname", "email", "profile_image")
-            .containsExactly(nickname, email, profile_image);
+            .extracting("nickname", "email", "profileImage")
+            .containsExactly(nickname, email, profileImage);
     }
 
     private UserInfo createUserInfo(String nickname, String email,

--- a/src/test/java/ds/project/toy/domain/user/entity/UserInfoTest.java
+++ b/src/test/java/ds/project/toy/domain/user/entity/UserInfoTest.java
@@ -1,0 +1,21 @@
+package ds.project.toy.domain.user.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ds.project.toy.IntegrationTestSupport;
+import ds.project.toy.domain.user.vo.UserInfoRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserInfoTest extends IntegrationTestSupport {
+
+    @DisplayName(value = "user role을 가진 userInfo를 생성한다.")
+    @Test
+    void creatUser() {
+        //given when
+        UserInfo userInfo = UserInfo.creatUser("email", "nickname");
+
+        //then
+        assertThat(userInfo.getRole()).isEqualTo(UserInfoRole.ROLE_USER);
+    }
+}

--- a/src/test/java/ds/project/toy/domain/user/repository/SocialLoginRepositoryTest.java
+++ b/src/test/java/ds/project/toy/domain/user/repository/SocialLoginRepositoryTest.java
@@ -31,7 +31,7 @@ class SocialLoginRepositoryTest extends IntegrationTestSupport {
         Optional<SocialLogin> socialLogin = socialLoginRepository.findByProviderProviderAndSocialId(
             provider, socialId);
         //then
-        assertThat(socialLogin.isPresent()).isTrue();
+        assertThat(socialLogin).isPresent();
         assertThat(socialLogin.get().getProvider().getProvider()).isEqualTo(provider);
         assertThat(socialLogin.get().getSocialId()).isEqualTo(socialId);
     }

--- a/src/test/java/ds/project/toy/domain/user/repository/SocialLoginRepositoryTest.java
+++ b/src/test/java/ds/project/toy/domain/user/repository/SocialLoginRepositoryTest.java
@@ -18,7 +18,7 @@ class SocialLoginRepositoryTest extends IntegrationTestSupport {
 
     @DisplayName(value = "소셜 로그인 제공자와 소셜 로그인 id에 따른 소셜 로그인엔티티를 조회한다.")
     @Test
-    public void findByProviderProviderAndSocialId() {
+    void findByProviderProviderAndSocialId() {
         //given
         OAuth2Provider provider = OAuth2Provider.KAKAO;
         String socialId = "SocialId";

--- a/src/test/java/ds/project/toy/domain/user/repository/SocialProviderRepositoryTest.java
+++ b/src/test/java/ds/project/toy/domain/user/repository/SocialProviderRepositoryTest.java
@@ -14,7 +14,7 @@ class SocialProviderRepositoryTest extends IntegrationTestSupport {
 
     @DisplayName(value = "소셜로그인 제공자에 따른 활성화된 소셜 로그인 제공자엔티티를 조회한다.")
     @Test
-    public void findByProviderAndState() {
+    void findByProviderAndState() {
         //given
         OAuth2Provider provider = OAuth2Provider.KAKAO;
         SocialProviderState state = SocialProviderState.ACTIVE;

--- a/src/test/java/ds/project/toy/domain/user/repository/SocialProviderRepositoryTest.java
+++ b/src/test/java/ds/project/toy/domain/user/repository/SocialProviderRepositoryTest.java
@@ -23,7 +23,7 @@ class SocialProviderRepositoryTest extends IntegrationTestSupport {
         Optional<SocialProvider> socialProvider = socialProviderRepository.findByProviderAndState(
             provider, state);
         //then
-        assertThat(socialProvider.isPresent()).isTrue();
+        assertThat(socialProvider).isPresent();
         assertThat(socialProvider.get().getProvider()).isEqualTo(provider);
     }
 

--- a/src/test/java/ds/project/toy/domain/user/repository/UserInfoRepositoryTest.java
+++ b/src/test/java/ds/project/toy/domain/user/repository/UserInfoRepositoryTest.java
@@ -15,7 +15,7 @@ class UserInfoRepositoryTest extends IntegrationTestSupport {
 
     @DisplayName(value = "유저 ID와 state를 가진 유저정보를 조회한다.")
     @Test
-    public void findByUserIdAndState() {
+    void findByUserIdAndState() {
         //given
         UserInfo userInfo1 = createUserInfo("nickname1", "email1@gmail.com",
             UserInfoRole.ROLE_USER, UserInfoState.ACTIVE);
@@ -38,7 +38,7 @@ class UserInfoRepositoryTest extends IntegrationTestSupport {
 
     @DisplayName(value = "닉네임과 상태로 활성화된 유저가 존재하는지 확인한다.")
     @Test
-    public void existsByNicknameAndState() {
+    void existsByNicknameAndState() {
         //given
         String nickname = "nickname1";
         UserInfo userInfo1 = createUserInfo(nickname, "email1@gmail.com",

--- a/src/test/java/ds/project/toy/global/config/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/ds/project/toy/global/config/security/jwt/JwtTokenProviderTest.java
@@ -39,7 +39,7 @@ class JwtTokenProviderTest extends IntegrationTestSupport {
 
     @DisplayName(value = "리프레시 토큰으로 유저아이디를 조회한다.")
     @Test
-    public void getUserIdFromRefreshToken() {
+    void getUserIdFromRefreshToken() {
         //given
         String userId = "id";
         AuthToken authToken = jwtTokenProvider.createTokenAndStore(userId);

--- a/src/test/java/ds/project/toy/global/util/FileUtilTest.java
+++ b/src/test/java/ds/project/toy/global/util/FileUtilTest.java
@@ -12,7 +12,7 @@ class FileUtilTest extends IntegrationTestSupport {
 
     @DisplayName(value = "이미지 파일의 속성이 jpg인지 판별한다.")
     @Test
-    public void isImageFileWithJPG() {
+    void isImageFileWithJPG() {
         //given
         MockMultipartFile mockMultipartFile = new MockMultipartFile("image", "test.jpg",
             MediaType.IMAGE_JPEG_VALUE, "hello.jpg".getBytes());
@@ -24,7 +24,7 @@ class FileUtilTest extends IntegrationTestSupport {
 
     @DisplayName(value = "이미지 파일의 속성이 png인지 판별한다.")
     @Test
-    public void isImageFileWithPNG() throws Exception {
+    void isImageFileWithPNG() {
         //given
         MockMultipartFile mockMultipartFile = new MockMultipartFile("image", "test.png",
             MediaType.IMAGE_PNG_VALUE, "hello.jpg".getBytes());

--- a/src/test/java/ds/project/toy/global/util/FileUtilTest.java
+++ b/src/test/java/ds/project/toy/global/util/FileUtilTest.java
@@ -21,6 +21,7 @@ class FileUtilTest extends IntegrationTestSupport {
         //then
         assertThat(result).isTrue();
     }
+
     @DisplayName(value = "이미지 파일의 속성이 png인지 판별한다.")
     @Test
     public void isImageFileWithPNG() throws Exception {
@@ -31,5 +32,40 @@ class FileUtilTest extends IntegrationTestSupport {
         boolean result = fileUtil.isImageFile(mockMultipartFile);
         //then
         assertThat(result).isTrue();
+    }
+
+    @DisplayName(value = "파일의 확장자가 없을 경우 false를 반환한다.")
+    @Test
+    void isImageFileWithoutExtension() {
+        //given
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("image", "test",
+            MediaType.IMAGE_PNG_VALUE, "hello".getBytes());
+        //when
+        boolean result = fileUtil.isImageFile(mockMultipartFile);
+        //then
+        assertThat(result).isFalse();
+    }
+
+    @DisplayName(value = "파일의 content type이 없을 경우 false를 반환한다.")
+    @Test
+    void isImageFileWithoutContentType() {
+        //given
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("image", "test.png",
+            null, "test.png".getBytes());
+        //when
+        boolean result = fileUtil.isImageFile(mockMultipartFile);
+        //then
+        assertThat(result).isFalse();
+    }
+    @DisplayName(value = "파일의 content type이 허용된 type이 아닐 경우 false를 반환한다.")
+    @Test
+    void isImageFileWithOtherContentType() {
+        //given
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("image", "test.png",
+            MediaType.TEXT_PLAIN_VALUE, "test.png".getBytes());
+        //when
+        boolean result = fileUtil.isImageFile(mockMultipartFile);
+        //then
+        assertThat(result).isFalse();
     }
 }


### PR DESCRIPTION
##  이슈
- [x] #58
## 작업 내용
 - userInfo의 createUser methos 삭제
- 프로필 이미지 변경의 예외 test 작성
- userInfo의 유저 생성 test 작성
- 이미지 판변 method false 반환 test code 작성
- 불필요한 test를 jacoco report에서 제외
- test code의 접근 제어자 public 삭제
- 사용하지 않는 라이브러리 삭제
- 프로필 이미지 변경 URI 변경 및 response body json key 수정
- test code optinal 확인 방식 수정
- instance of cast 방식 수정
- OAuth2UserInfoFactory private 생성자 추가