### PR TITLE
Fix: gitghub action sonar cloud analyze plugin 변경

### DIFF
--- a/.github/workflows/sonarcloud-analyze.yml
+++ b/.github/workflows/sonarcloud-analyze.yml
@@ -27,7 +27,7 @@ jobs:
         run: ./gradlew build
 
       - name: Analyze with SonarCloud
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@master
         id: analyze-sonarcloud
         continue-on-error: true
         env:


### PR DESCRIPTION
##  이슈
- [ ] #80
## 작업 내용
- 기존 sonarcloud-github-action이 deprecated 됨에 따라
- sonarqube-scan-actiond으로 변경